### PR TITLE
made space between users list and bottom tab navigation

### DIFF
--- a/src/screens/home.tsx
+++ b/src/screens/home.tsx
@@ -191,7 +191,7 @@ const styles = StyleSheet.create({
     flexDirection: "column",
     gap: 2,
     width: "100%",
-    marginBottom: 10,
+    marginBottom: 0,
   },
   friendsRow: {
     display: "flex",


### PR DESCRIPTION
made a space between all users list and bottom tab navigation because for me it looked like the list was bleeding onto the tab navigation.